### PR TITLE
Add tests for 7135 Decatur

### DIFF
--- a/test_cases/7135_decatur.json
+++ b/test_cases/7135_decatur.json
@@ -1,0 +1,163 @@
+{
+  "name": "7135 S Decatur Blvd, Las Vegas, NV 89118",
+  "description": "Various versions of one address technically in one city within another, taken from the OSM list at https://trac.openstreetmap.org/ticket/5363",
+  "priorityThresh": 5,
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "7135 S Decatur Blvd, Enterprise, NV 89118"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "7135 South Decatur Boulevard",
+            "housenumber": "7135",
+            "street": "South Decatur Boulevard",
+            "postalcode": "89118",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "Nevada",
+            "region_a": "NV",
+            "county": "Clark County",
+            "locality": "Enterprise",
+            "neighbourhood": "Boulder Junction",
+            "label": "7135 South Decatur Boulevard, Enterprise, NV"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "7135 S Decatur Blvd, NV 89118"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "7135 South Decatur Boulevard",
+            "housenumber": "7135",
+            "street": "South Decatur Boulevard",
+            "postalcode": "89118",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "Nevada",
+            "region_a": "NV",
+            "county": "Clark County",
+            "locality": "Enterprise",
+            "neighbourhood": "Boulder Junction",
+            "label": "7135 South Decatur Boulevard, Enterprise, NV"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "7135 S Decatur Blvd, Clark County"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "7135 South Decatur Boulevard",
+            "housenumber": "7135",
+            "street": "South Decatur Boulevard",
+            "postalcode": "89118",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "Nevada",
+            "region_a": "NV",
+            "county": "Clark County",
+            "locality": "Enterprise",
+            "neighbourhood": "Boulder Junction",
+            "label": "7135 South Decatur Boulevard, Enterprise, NV"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "7135 South Decatur Boulevard"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "7135 South Decatur Boulevard",
+            "housenumber": "7135",
+            "street": "South Decatur Boulevard",
+            "postalcode": "89118",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "Nevada",
+            "region_a": "NV",
+            "county": "Clark County",
+            "locality": "Enterprise",
+            "neighbourhood": "Boulder Junction",
+            "label": "7135 South Decatur Boulevard, Enterprise, NV"
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "7135 S Decatur Blvd"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "7135 South Decatur Boulevard",
+            "housenumber": "7135",
+            "street": "South Decatur Boulevard",
+            "postalcode": "89118",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "Nevada",
+            "region_a": "NV",
+            "county": "Clark County",
+            "locality": "Enterprise",
+            "neighbourhood": "Boulder Junction",
+            "label": "7135 South Decatur Boulevard, Enterprise, NV"
+          }
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "7135 S Decatur Blvd, Las Vegas, NV 89118"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "7135 South Decatur Boulevard",
+            "housenumber": "7135",
+            "street": "South Decatur Boulevard",
+            "postalcode": "89118",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "Nevada",
+            "region_a": "NV",
+            "county": "Clark County",
+            "locality": "Enterprise",
+            "neighbourhood": "Boulder Junction",
+            "label": "7135 South Decatur Boulevard, Enterprise, NV"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I saw a [thread](https://trac.openstreetmap.org/ticket/5363) about a
somewhat difficult address to parse in OSM (turned out to be because of
a bad relation for the Las Vegas boundary, and figured I'd add the test
cases they used, particularly to check out the new address schema
changes from pelias/schema#77
