### PR TITLE
Resolve more placeholders

### DIFF
--- a/test_cases/feedback_fail.json
+++ b/test_cases/feedback_fail.json
@@ -100,7 +100,22 @@
         "text": "1065 La Avenida St., Mountain View, CA"
       },
       "expected": {
-        "properties": "1065, La Avenida Street, Mountain View, Santa Clara County, California, 94043, United States of America"
+        "properties": [
+          {
+            "name": "1065 Lane Avenida Avenue",
+            "housenumber": "1065",
+            "street": "Lane Avenida Avenue",
+            "postalcode": "94043",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "California",
+            "region_a": "CA",
+            "county": "Santa Clara County",
+            "locality": "Mountain View",
+            "neighbourhood": "Mountain View South",
+            "label": "1065 Lane Avenida Avenue, Mountain View, CA"
+          }
+        ]
       }
     },
     {

--- a/test_cases/feedback_fail.json
+++ b/test_cases/feedback_fail.json
@@ -847,7 +847,18 @@
         "text": "taj mahal"
       },
       "expected": {
-        "properties": "Taj Mahal, Taj East Gate Road, Taj Ganj, Agra, Uttar Pradesh, 282001, India"
+        "properties": [
+          {
+            "name": "Taj Mahal",
+            "country_a": "IND",
+            "country": "India",
+            "region": "Uttar Pradesh",
+            "county": "Agra",
+            "locality": "Ägra",
+            "neighbourhood": "Nagla Kachhpura",
+            "label": "Taj Mahal, Ägra, India"
+          }
+        ]
       }
     },
     {


### PR DESCRIPTION
I figure I'll periodically go through and run the [resolve placeholders](https://github.com/pelias/fuzzy-tester/blob/master/scripts/resolvePlaceholders.js) script.

This time we get Taj Mahal correctly, and we also get the address of the Microsoft office in Mountain View, CA correctly, or at least as correctly as OpenAddresses gets it (see openaddresses/openaddresses#1456).
