### PR TITLE
Run fuzzy tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 before_script:
     - npm prune
-    - 'echo "{ \"mapzen\": { \"api_key\": { \"pelias.mapzen.com\": \"$API_KEY\" } } }" > ~/pelias.json'
+    - 'echo "{ \"mapzen\": { \"api_key\": { \"search.mapzen.com\": \"$API_KEY\" } }, \"acceptance-tests\": { \"endpoints\": { \"prod\": \"http://search.mapzen.com/v1\" } } }" > ~/pelias.json'
 node_js:
   - 6
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
-script:
-  - npm test -- -e prod
+before_script:
+    - 'echo "{ \"mapzen\": { \"api_key\": { \"pelias.mapzen.com\": \"$API_KEY\" } } }" > ~/pelias.json'
 node_js:
   - 0.12
   - 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 before_script:
+    - npm prune
     - 'echo "{ \"mapzen\": { \"api_key\": { \"pelias.mapzen.com\": \"$API_KEY\" } } }" > ~/pelias.json'
 node_js:
   - 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 before_script:
     - 'echo "{ \"mapzen\": { \"api_key\": { \"pelias.mapzen.com\": \"$API_KEY\" } } }" > ~/pelias.json'
 node_js:
-  - 0.12
-  - 4
-  - 5
   - 6
 sudo: false
 cache:
@@ -12,7 +9,3 @@ cache:
     - node_modules
 before_script:
   - npm prune
-matrix:
-  fast_finish: true
-  allow_failures:
-    - node_js: 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,3 @@ sudo: false
 cache:
   directories:
     - node_modules
-before_script:
-  - npm prune


### PR DESCRIPTION
With a little sneaky `before_script`ing, we can run the fuzzy-tests on Travis with our own API key. This is nice since it gives us a regular run of the tests, and because Travis saves the build logs we can look at changes over time.

Note, unlike the [acceptance-tests](https://github.com/pelias/acceptance-tests/pull/270), these are run against the Fastly endpoint. There's way too many fuzzy-tests to not take advantage of caching where we can.
