### PR TITLE
Move from TravisCI to GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,23 @@
+name: Continuous Integration
+on: push
+jobs:
+  unit-tests:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+        node-version:
+          - 12.x
+          - 14.x
+          - 16.x
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Install node.js ${{ matrix.node-version }}'
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '${{ matrix.node-version }}'
+      - name: Run lint
+        run: |
+          npm install
+          npm run lint && npm ls

--- a/.lgtm
+++ b/.lgtm
@@ -1,1 +1,0 @@
-pattern = "(?i):shipit:|:\\+1:|LGTM"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - 8
-sudo: false
-script: npm run lint && npm ls
-cache:
-  directories:
-    - node_modules

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/pelias/fuzzy-tests.png)](https://travis-ci.org/pelias/fuzzy-tests)
-
 # Fuzzy tests
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/pelias/fuzzy-tests.svg)](https://greenkeeper.io/)

--- a/package.json
+++ b/package.json
@@ -35,8 +35,5 @@
   "pre-commit": [
     "lint",
     "validate"
-  ],
-  "engines": {
-    "npm": "~2.0.0"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "validate": "npm ls"
   },
   "dependencies": {
-    "pelias-fuzzy-tester": "^1.18.1"
+    "pelias-fuzzy-tester": "^1.19.0"
   },
   "devDependencies": {
     "jshint": "^2.9.4",


### PR DESCRIPTION
This repository is super simple (no unit tests), but it still makes sense to switch over to GitHub Actions. We also remove the super ancient `lgtm` config (remember when GitHub didn't have pull request reviews?)