### PR TITLE
"City of X" checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "validate": "npm ls"
   },
   "dependencies": {
-    "pelias-fuzzy-tester": "^1.19.0"
+    "pelias-fuzzy-tester": "^1.21.1"
   },
   "devDependencies": {
     "jshint": "^2.9.4",

--- a/test_cases/top_us_cities.json
+++ b/test_cases/top_us_cities.json
@@ -32,6 +32,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of New York"
+          }
+        ]
       }
     },
     {
@@ -54,6 +61,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of New York"
+          }
+        ]
       }
     },
     {
@@ -73,6 +87,13 @@
             "name": "Los Angeles",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Los Angeles"
           }
         ]
       }
@@ -97,6 +118,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Los Angeles"
+          }
+        ]
       }
     },
     {
@@ -116,6 +144,13 @@
             "name": "Chicago",
             "region": "Illinois",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chicago"
           }
         ]
       }
@@ -140,6 +175,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chicago"
+          }
+        ]
       }
     },
     {
@@ -159,6 +201,13 @@
             "name": "Houston",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Houston"
           }
         ]
       }
@@ -183,6 +232,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Houston"
+          }
+        ]
       }
     },
     {
@@ -202,6 +258,13 @@
             "name": "Phoenix",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Phoenix"
           }
         ]
       }
@@ -226,6 +289,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Phoenix"
+          }
+        ]
       }
     },
     {
@@ -245,6 +315,13 @@
             "name": "Philadelphia",
             "region": "Pennsylvania",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Philadelphia"
           }
         ]
       }
@@ -269,6 +346,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Philadelphia"
+          }
+        ]
       }
     },
     {
@@ -288,6 +372,13 @@
             "name": "San Antonio",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Antonio"
           }
         ]
       }
@@ -312,6 +403,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Antonio"
+          }
+        ]
       }
     },
     {
@@ -331,6 +429,13 @@
             "name": "San Diego",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Diego"
           }
         ]
       }
@@ -355,6 +460,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Diego"
+          }
+        ]
       }
     },
     {
@@ -374,6 +486,13 @@
             "name": "Dallas",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Dallas"
           }
         ]
       }
@@ -398,6 +517,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Dallas"
+          }
+        ]
       }
     },
     {
@@ -417,6 +543,13 @@
             "name": "San Jose",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Jose"
           }
         ]
       }
@@ -441,6 +574,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Jose"
+          }
+        ]
       }
     },
     {
@@ -460,6 +600,13 @@
             "name": "Austin",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Austin"
           }
         ]
       }
@@ -484,6 +631,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Austin"
+          }
+        ]
       }
     },
     {
@@ -503,6 +657,13 @@
             "name": "Jacksonville",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Jacksonville"
           }
         ]
       }
@@ -527,6 +688,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Jacksonville"
+          }
+        ]
       }
     },
     {
@@ -546,6 +714,13 @@
             "name": "Fort Worth",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fort Worth"
           }
         ]
       }
@@ -570,6 +745,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fort Worth"
+          }
+        ]
       }
     },
     {
@@ -589,6 +771,13 @@
             "name": "Columbus",
             "region": "Ohio",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Columbus"
           }
         ]
       }
@@ -613,6 +802,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Columbus"
+          }
+        ]
       }
     },
     {
@@ -632,6 +828,13 @@
             "name": "San Francisco",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Francisco"
           }
         ]
       }
@@ -656,6 +859,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Francisco"
+          }
+        ]
       }
     },
     {
@@ -675,6 +885,13 @@
             "name": "Charlotte",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Charlotte"
           }
         ]
       }
@@ -699,6 +916,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Charlotte"
+          }
+        ]
       }
     },
     {
@@ -718,6 +942,13 @@
             "name": "Indianapolis",
             "region": "Indiana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Indianapolis"
           }
         ]
       }
@@ -742,6 +973,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Indianapolis"
+          }
+        ]
       }
     },
     {
@@ -761,6 +999,13 @@
             "name": "Seattle",
             "region": "Washington",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Seattle"
           }
         ]
       }
@@ -785,6 +1030,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Seattle"
+          }
+        ]
       }
     },
     {
@@ -804,6 +1056,13 @@
             "name": "Denver",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Denver"
           }
         ]
       }
@@ -828,6 +1087,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Denver"
+          }
+        ]
       }
     },
     {
@@ -847,6 +1113,13 @@
             "name": "Washington",
             "region": "District of Columbia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Washington"
           }
         ]
       }
@@ -871,6 +1144,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Washington"
+          }
+        ]
       }
     },
     {
@@ -890,6 +1170,13 @@
             "name": "Boston",
             "region": "Massachusetts",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Boston"
           }
         ]
       }
@@ -914,6 +1201,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Boston"
+          }
+        ]
       }
     },
     {
@@ -933,6 +1227,13 @@
             "name": "El Paso",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of El Paso"
           }
         ]
       }
@@ -957,6 +1258,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of El Paso"
+          }
+        ]
       }
     },
     {
@@ -976,6 +1284,13 @@
             "name": "Detroit",
             "region": "Michigan",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Detroit"
           }
         ]
       }
@@ -1000,6 +1315,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Detroit"
+          }
+        ]
       }
     },
     {
@@ -1019,6 +1341,13 @@
             "name": "Nashville",
             "region": "Tennessee",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Nashville"
           }
         ]
       }
@@ -1043,6 +1372,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Nashville"
+          }
+        ]
       }
     },
     {
@@ -1062,6 +1398,13 @@
             "name": "Portland",
             "region": "Oregon",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Portland"
           }
         ]
       }
@@ -1086,6 +1429,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Portland"
+          }
+        ]
       }
     },
     {
@@ -1105,6 +1455,13 @@
             "name": "Memphis",
             "region": "Tennessee",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Memphis"
           }
         ]
       }
@@ -1129,6 +1486,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Memphis"
+          }
+        ]
       }
     },
     {
@@ -1148,6 +1512,13 @@
             "name": "Oklahoma City",
             "region": "Oklahoma",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Oklahoma City"
           }
         ]
       }
@@ -1172,6 +1543,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Oklahoma City"
+          }
+        ]
       }
     },
     {
@@ -1191,6 +1569,13 @@
             "name": "Las Vegas",
             "region": "Nevada",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Las Vegas"
           }
         ]
       }
@@ -1215,6 +1600,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Las Vegas"
+          }
+        ]
       }
     },
     {
@@ -1234,6 +1626,13 @@
             "name": "Louisville",
             "region": "Kentucky",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Louisville"
           }
         ]
       }
@@ -1258,6 +1657,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Louisville"
+          }
+        ]
       }
     },
     {
@@ -1277,6 +1683,13 @@
             "name": "Baltimore",
             "region": "Maryland",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Baltimore"
           }
         ]
       }
@@ -1301,6 +1714,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Baltimore"
+          }
+        ]
       }
     },
     {
@@ -1320,6 +1740,13 @@
             "name": "Milwaukee",
             "region": "Wisconsin",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Milwaukee"
           }
         ]
       }
@@ -1344,6 +1771,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Milwaukee"
+          }
+        ]
       }
     },
     {
@@ -1363,6 +1797,13 @@
             "name": "Albuquerque",
             "region": "New Mexico",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Albuquerque"
           }
         ]
       }
@@ -1387,6 +1828,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Albuquerque"
+          }
+        ]
       }
     },
     {
@@ -1406,6 +1854,13 @@
             "name": "Tucson",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tucson"
           }
         ]
       }
@@ -1430,6 +1885,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tucson"
+          }
+        ]
       }
     },
     {
@@ -1449,6 +1911,13 @@
             "name": "Fresno",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fresno"
           }
         ]
       }
@@ -1473,6 +1942,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fresno"
+          }
+        ]
       }
     },
     {
@@ -1492,6 +1968,13 @@
             "name": "Mesa",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Mesa"
           }
         ]
       }
@@ -1516,6 +1999,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Mesa"
+          }
+        ]
       }
     },
     {
@@ -1535,6 +2025,13 @@
             "name": "Sacramento",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sacramento"
           }
         ]
       }
@@ -1559,6 +2056,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sacramento"
+          }
+        ]
       }
     },
     {
@@ -1578,6 +2082,13 @@
             "name": "Atlanta",
             "region": "Georgia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Atlanta"
           }
         ]
       }
@@ -1602,6 +2113,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Atlanta"
+          }
+        ]
       }
     },
     {
@@ -1621,6 +2139,13 @@
             "name": "Kansas City",
             "region": "Missouri",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Kansas City"
           }
         ]
       }
@@ -1645,6 +2170,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Kansas City"
+          }
+        ]
       }
     },
     {
@@ -1664,6 +2196,13 @@
             "name": "Colorado Springs",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Colorado Springs"
           }
         ]
       }
@@ -1688,6 +2227,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Colorado Springs"
+          }
+        ]
       }
     },
     {
@@ -1707,6 +2253,13 @@
             "name": "Miami",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Miami"
           }
         ]
       }
@@ -1731,6 +2284,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Miami"
+          }
+        ]
       }
     },
     {
@@ -1750,6 +2310,13 @@
             "name": "Raleigh",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Raleigh"
           }
         ]
       }
@@ -1774,6 +2341,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Raleigh"
+          }
+        ]
       }
     },
     {
@@ -1793,6 +2367,13 @@
             "name": "Omaha",
             "region": "Nebraska",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Omaha"
           }
         ]
       }
@@ -1817,6 +2398,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Omaha"
+          }
+        ]
       }
     },
     {
@@ -1836,6 +2424,13 @@
             "name": "Long Beach",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Long Beach"
           }
         ]
       }
@@ -1860,6 +2455,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Long Beach"
+          }
+        ]
       }
     },
     {
@@ -1879,6 +2481,13 @@
             "name": "Virginia Beach",
             "region": "Virginia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Virginia Beach"
           }
         ]
       }
@@ -1903,6 +2512,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Virginia Beach"
+          }
+        ]
       }
     },
     {
@@ -1922,6 +2538,13 @@
             "name": "Oakland",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Oakland"
           }
         ]
       }
@@ -1946,6 +2569,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Oakland"
+          }
+        ]
       }
     },
     {
@@ -1965,6 +2595,13 @@
             "name": "Minneapolis",
             "region": "Minnesota",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Minneapolis"
           }
         ]
       }
@@ -1989,6 +2626,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Minneapolis"
+          }
+        ]
       }
     },
     {
@@ -2008,6 +2652,13 @@
             "name": "Tulsa",
             "region": "Oklahoma",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tulsa"
           }
         ]
       }
@@ -2032,6 +2683,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tulsa"
+          }
+        ]
       }
     },
     {
@@ -2051,6 +2709,13 @@
             "name": "Arlington",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Arlington"
           }
         ]
       }
@@ -2075,6 +2740,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Arlington"
+          }
+        ]
       }
     },
     {
@@ -2094,6 +2766,13 @@
             "name": "Tampa",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tampa"
           }
         ]
       }
@@ -2118,6 +2797,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tampa"
+          }
+        ]
       }
     },
     {
@@ -2137,6 +2823,13 @@
             "name": "New Orleans",
             "region": "Louisiana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of New Orleans"
           }
         ]
       }
@@ -2161,6 +2854,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of New Orleans"
+          }
+        ]
       }
     },
     {
@@ -2180,6 +2880,13 @@
             "name": "Wichita",
             "region": "Kansas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Wichita"
           }
         ]
       }
@@ -2204,6 +2911,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Wichita"
+          }
+        ]
       }
     },
     {
@@ -2223,6 +2937,13 @@
             "name": "Cleveland",
             "region": "Ohio",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cleveland"
           }
         ]
       }
@@ -2247,6 +2968,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cleveland"
+          }
+        ]
       }
     },
     {
@@ -2266,6 +2994,13 @@
             "name": "Bakersfield",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Bakersfield"
           }
         ]
       }
@@ -2290,6 +3025,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Bakersfield"
+          }
+        ]
       }
     },
     {
@@ -2309,6 +3051,13 @@
             "name": "Aurora",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Aurora"
           }
         ]
       }
@@ -2333,6 +3082,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Aurora"
+          }
+        ]
       }
     },
     {
@@ -2352,6 +3108,13 @@
             "name": "Anaheim",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Anaheim"
           }
         ]
       }
@@ -2376,6 +3139,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Anaheim"
+          }
+        ]
       }
     },
     {
@@ -2395,6 +3165,13 @@
             "name": "Honolulu",
             "region": "Hawaii",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Honolulu"
           }
         ]
       }
@@ -2419,6 +3196,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Honolulu"
+          }
+        ]
       }
     },
     {
@@ -2438,6 +3222,13 @@
             "name": "Santa Ana",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Ana"
           }
         ]
       }
@@ -2462,6 +3253,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Ana"
+          }
+        ]
       }
     },
     {
@@ -2481,6 +3279,13 @@
             "name": "Riverside",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Riverside"
           }
         ]
       }
@@ -2505,6 +3310,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Riverside"
+          }
+        ]
       }
     },
     {
@@ -2524,6 +3336,13 @@
             "name": "Corpus Christi",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Corpus Christi"
           }
         ]
       }
@@ -2548,6 +3367,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Corpus Christi"
+          }
+        ]
       }
     },
     {
@@ -2567,6 +3393,13 @@
             "name": "Lexington",
             "region": "Kentucky",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lexington"
           }
         ]
       }
@@ -2591,6 +3424,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lexington"
+          }
+        ]
       }
     },
     {
@@ -2610,6 +3450,13 @@
             "name": "Stockton",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Stockton"
           }
         ]
       }
@@ -2634,6 +3481,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Stockton"
+          }
+        ]
       }
     },
     {
@@ -2653,6 +3507,13 @@
             "name": "Henderson",
             "region": "Nevada",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Henderson"
           }
         ]
       }
@@ -2677,6 +3538,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Henderson"
+          }
+        ]
       }
     },
     {
@@ -2696,6 +3564,13 @@
             "name": "Saint Paul",
             "region": "Minnesota",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Saint Paul"
           }
         ]
       }
@@ -2720,6 +3595,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Saint Paul"
+          }
+        ]
       }
     },
     {
@@ -2739,6 +3621,13 @@
             "name": "St. Louis",
             "region": "Missouri",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of St. Louis"
           }
         ]
       }
@@ -2763,6 +3652,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of St. Louis"
+          }
+        ]
       }
     },
     {
@@ -2782,6 +3678,13 @@
             "name": "Cincinnati",
             "region": "Ohio",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cincinnati"
           }
         ]
       }
@@ -2806,6 +3709,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cincinnati"
+          }
+        ]
       }
     },
     {
@@ -2825,6 +3735,13 @@
             "name": "Pittsburgh",
             "region": "Pennsylvania",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pittsburgh"
           }
         ]
       }
@@ -2849,6 +3766,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pittsburgh"
+          }
+        ]
       }
     },
     {
@@ -2868,6 +3792,13 @@
             "name": "Greensboro",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Greensboro"
           }
         ]
       }
@@ -2892,6 +3823,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Greensboro"
+          }
+        ]
       }
     },
     {
@@ -2911,6 +3849,13 @@
             "name": "Anchorage",
             "region": "Alaska",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Anchorage"
           }
         ]
       }
@@ -2935,6 +3880,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Anchorage"
+          }
+        ]
       }
     },
     {
@@ -2954,6 +3906,13 @@
             "name": "Plano",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Plano"
           }
         ]
       }
@@ -2978,6 +3937,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Plano"
+          }
+        ]
       }
     },
     {
@@ -2997,6 +3963,13 @@
             "name": "Lincoln",
             "region": "Nebraska",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lincoln"
           }
         ]
       }
@@ -3021,6 +3994,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lincoln"
+          }
+        ]
       }
     },
     {
@@ -3040,6 +4020,13 @@
             "name": "Orlando",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Orlando"
           }
         ]
       }
@@ -3064,6 +4051,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Orlando"
+          }
+        ]
       }
     },
     {
@@ -3083,6 +4077,13 @@
             "name": "Irvine",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Irvine"
           }
         ]
       }
@@ -3107,6 +4108,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Irvine"
+          }
+        ]
       }
     },
     {
@@ -3126,6 +4134,13 @@
             "name": "Newark",
             "region": "New Jersey",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Newark"
           }
         ]
       }
@@ -3150,6 +4165,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Newark"
+          }
+        ]
       }
     },
     {
@@ -3169,6 +4191,13 @@
             "name": "Toledo",
             "region": "Ohio",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Toledo"
           }
         ]
       }
@@ -3193,6 +4222,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Toledo"
+          }
+        ]
       }
     },
     {
@@ -3212,6 +4248,13 @@
             "name": "Durham",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Durham"
           }
         ]
       }
@@ -3236,6 +4279,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Durham"
+          }
+        ]
       }
     },
     {
@@ -3255,6 +4305,13 @@
             "name": "Chula Vista",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chula Vista"
           }
         ]
       }
@@ -3279,6 +4336,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chula Vista"
+          }
+        ]
       }
     },
     {
@@ -3298,6 +4362,13 @@
             "name": "Fort Wayne",
             "region": "Indiana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fort Wayne"
           }
         ]
       }
@@ -3322,6 +4393,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fort Wayne"
+          }
+        ]
       }
     },
     {
@@ -3341,6 +4419,13 @@
             "name": "Jersey City",
             "region": "New Jersey",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Jersey City"
           }
         ]
       }
@@ -3365,6 +4450,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Jersey City"
+          }
+        ]
       }
     },
     {
@@ -3384,6 +4476,13 @@
             "name": "St. Petersburg",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of St. Petersburg"
           }
         ]
       }
@@ -3408,6 +4507,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of St. Petersburg"
+          }
+        ]
       }
     },
     {
@@ -3427,6 +4533,13 @@
             "name": "Laredo",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Laredo"
           }
         ]
       }
@@ -3451,6 +4564,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Laredo"
+          }
+        ]
       }
     },
     {
@@ -3470,6 +4590,13 @@
             "name": "Madison",
             "region": "Wisconsin",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Madison"
           }
         ]
       }
@@ -3494,6 +4621,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Madison"
+          }
+        ]
       }
     },
     {
@@ -3513,6 +4647,13 @@
             "name": "Chandler",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chandler"
           }
         ]
       }
@@ -3537,6 +4678,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chandler"
+          }
+        ]
       }
     },
     {
@@ -3556,6 +4704,13 @@
             "name": "Buffalo",
             "region": "New York",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Buffalo"
           }
         ]
       }
@@ -3580,6 +4735,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Buffalo"
+          }
+        ]
       }
     },
     {
@@ -3599,6 +4761,13 @@
             "name": "Lubbock",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lubbock"
           }
         ]
       }
@@ -3623,6 +4792,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lubbock"
+          }
+        ]
       }
     },
     {
@@ -3642,6 +4818,13 @@
             "name": "Scottsdale",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Scottsdale"
           }
         ]
       }
@@ -3666,6 +4849,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Scottsdale"
+          }
+        ]
       }
     },
     {
@@ -3685,6 +4875,13 @@
             "name": "Reno",
             "region": "Nevada",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Reno"
           }
         ]
       }
@@ -3709,6 +4906,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Reno"
+          }
+        ]
       }
     },
     {
@@ -3728,6 +4932,13 @@
             "name": "Glendale",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Glendale"
           }
         ]
       }
@@ -3752,6 +4963,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Glendale"
+          }
+        ]
       }
     },
     {
@@ -3771,6 +4989,13 @@
             "name": "Gilbert",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Gilbert"
           }
         ]
       }
@@ -3795,6 +5020,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Gilbert"
+          }
+        ]
       }
     },
     {
@@ -3814,6 +5046,13 @@
             "name": "Winston–Salem",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Winston–Salem"
           }
         ]
       }
@@ -3838,6 +5077,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Winston–Salem"
+          }
+        ]
       }
     },
     {
@@ -3857,6 +5103,13 @@
             "name": "North Las Vegas",
             "region": "Nevada",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of North Las Vegas"
           }
         ]
       }
@@ -3881,6 +5134,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of North Las Vegas"
+          }
+        ]
       }
     },
     {
@@ -3900,6 +5160,13 @@
             "name": "Norfolk",
             "region": "Virginia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Norfolk"
           }
         ]
       }
@@ -3924,6 +5191,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Norfolk"
+          }
+        ]
       }
     },
     {
@@ -3943,6 +5217,13 @@
             "name": "Chesapeake",
             "region": "Virginia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chesapeake"
           }
         ]
       }
@@ -3967,6 +5248,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chesapeake"
+          }
+        ]
       }
     },
     {
@@ -3986,6 +5274,13 @@
             "name": "Garland",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Garland"
           }
         ]
       }
@@ -4010,6 +5305,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Garland"
+          }
+        ]
       }
     },
     {
@@ -4029,6 +5331,13 @@
             "name": "Irving",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Irving"
           }
         ]
       }
@@ -4053,6 +5362,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Irving"
+          }
+        ]
       }
     },
     {
@@ -4072,6 +5388,13 @@
             "name": "Hialeah",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hialeah"
           }
         ]
       }
@@ -4096,6 +5419,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hialeah"
+          }
+        ]
       }
     },
     {
@@ -4115,6 +5445,13 @@
             "name": "Fremont",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fremont"
           }
         ]
       }
@@ -4139,6 +5476,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fremont"
+          }
+        ]
       }
     },
     {
@@ -4158,6 +5502,13 @@
             "name": "Boise",
             "region": "Idaho",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Boise"
           }
         ]
       }
@@ -4182,6 +5533,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Boise"
+          }
+        ]
       }
     },
     {
@@ -4201,6 +5559,13 @@
             "name": "Richmond",
             "region": "Virginia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Richmond"
           }
         ]
       }
@@ -4225,6 +5590,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Richmond"
+          }
+        ]
       }
     },
     {
@@ -4244,6 +5616,13 @@
             "name": "Baton Rouge",
             "region": "Louisiana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Baton Rouge"
           }
         ]
       }
@@ -4268,6 +5647,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Baton Rouge"
+          }
+        ]
       }
     },
     {
@@ -4287,6 +5673,13 @@
             "name": "Spokane",
             "region": "Washington",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Spokane"
           }
         ]
       }
@@ -4311,6 +5704,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Spokane"
+          }
+        ]
       }
     },
     {
@@ -4330,6 +5730,13 @@
             "name": "Des Moines",
             "region": "Iowa",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Des Moines"
           }
         ]
       }
@@ -4354,6 +5761,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Des Moines"
+          }
+        ]
       }
     },
     {
@@ -4373,6 +5787,13 @@
             "name": "Tacoma",
             "region": "Washington",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tacoma"
           }
         ]
       }
@@ -4397,6 +5818,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tacoma"
+          }
+        ]
       }
     },
     {
@@ -4416,6 +5844,13 @@
             "name": "San Bernardino",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Bernardino"
           }
         ]
       }
@@ -4440,6 +5875,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Bernardino"
+          }
+        ]
       }
     },
     {
@@ -4459,6 +5901,13 @@
             "name": "Modesto",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Modesto"
           }
         ]
       }
@@ -4483,6 +5932,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Modesto"
+          }
+        ]
       }
     },
     {
@@ -4502,6 +5958,13 @@
             "name": "Fontana",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fontana"
           }
         ]
       }
@@ -4526,6 +5989,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fontana"
+          }
+        ]
       }
     },
     {
@@ -4545,6 +6015,13 @@
             "name": "Santa Clarita",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Clarita"
           }
         ]
       }
@@ -4569,6 +6046,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Clarita"
+          }
+        ]
       }
     },
     {
@@ -4588,6 +6072,13 @@
             "name": "Birmingham",
             "region": "Alabama",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Birmingham"
           }
         ]
       }
@@ -4612,6 +6103,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Birmingham"
+          }
+        ]
       }
     },
     {
@@ -4631,6 +6129,13 @@
             "name": "Oxnard",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Oxnard"
           }
         ]
       }
@@ -4655,6 +6160,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Oxnard"
+          }
+        ]
       }
     },
     {
@@ -4674,6 +6186,13 @@
             "name": "Fayetteville",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fayetteville"
           }
         ]
       }
@@ -4698,6 +6217,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fayetteville"
+          }
+        ]
       }
     },
     {
@@ -4717,6 +6243,13 @@
             "name": "Moreno Valley",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Moreno Valley"
           }
         ]
       }
@@ -4741,6 +6274,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Moreno Valley"
+          }
+        ]
       }
     },
     {
@@ -4760,6 +6300,13 @@
             "name": "Rochester",
             "region": "New York",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rochester"
           }
         ]
       }
@@ -4784,6 +6331,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rochester"
+          }
+        ]
       }
     },
     {
@@ -4803,6 +6357,13 @@
             "name": "Glendale",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Glendale"
           }
         ]
       }
@@ -4827,6 +6388,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Glendale"
+          }
+        ]
       }
     },
     {
@@ -4846,6 +6414,13 @@
             "name": "Huntington Beach",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Huntington Beach"
           }
         ]
       }
@@ -4870,6 +6445,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Huntington Beach"
+          }
+        ]
       }
     },
     {
@@ -4889,6 +6471,13 @@
             "name": "Salt Lake City",
             "region": "Utah",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Salt Lake City"
           }
         ]
       }
@@ -4913,6 +6502,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Salt Lake City"
+          }
+        ]
       }
     },
     {
@@ -4932,6 +6528,13 @@
             "name": "Grand Rapids",
             "region": "Michigan",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Grand Rapids"
           }
         ]
       }
@@ -4956,6 +6559,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Grand Rapids"
+          }
+        ]
       }
     },
     {
@@ -4975,6 +6585,13 @@
             "name": "Amarillo",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Amarillo"
           }
         ]
       }
@@ -4999,6 +6616,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Amarillo"
+          }
+        ]
       }
     },
     {
@@ -5018,6 +6642,13 @@
             "name": "Yonkers",
             "region": "New York",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Yonkers"
           }
         ]
       }
@@ -5042,6 +6673,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Yonkers"
+          }
+        ]
       }
     },
     {
@@ -5061,6 +6699,13 @@
             "name": "Aurora",
             "region": "Illinois",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Aurora"
           }
         ]
       }
@@ -5085,6 +6730,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Aurora"
+          }
+        ]
       }
     },
     {
@@ -5104,6 +6756,13 @@
             "name": "Montgomery",
             "region": "Alabama",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Montgomery"
           }
         ]
       }
@@ -5128,6 +6787,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Montgomery"
+          }
+        ]
       }
     },
     {
@@ -5147,6 +6813,13 @@
             "name": "Akron",
             "region": "Ohio",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Akron"
           }
         ]
       }
@@ -5171,6 +6844,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Akron"
+          }
+        ]
       }
     },
     {
@@ -5190,6 +6870,13 @@
             "name": "Little Rock",
             "region": "Arkansas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Little Rock"
           }
         ]
       }
@@ -5214,6 +6901,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Little Rock"
+          }
+        ]
       }
     },
     {
@@ -5233,6 +6927,13 @@
             "name": "Huntsville",
             "region": "Alabama",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Huntsville"
           }
         ]
       }
@@ -5257,6 +6958,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Huntsville"
+          }
+        ]
       }
     },
     {
@@ -5276,6 +6984,13 @@
             "name": "Augusta",
             "region": "Georgia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Augusta"
           }
         ]
       }
@@ -5300,6 +7015,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Augusta"
+          }
+        ]
       }
     },
     {
@@ -5319,6 +7041,13 @@
             "name": "Port St. Lucie",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Port St. Lucie"
           }
         ]
       }
@@ -5343,6 +7072,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Port St. Lucie"
+          }
+        ]
       }
     },
     {
@@ -5362,6 +7098,13 @@
             "name": "Grand Prairie",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Grand Prairie"
           }
         ]
       }
@@ -5386,6 +7129,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Grand Prairie"
+          }
+        ]
       }
     },
     {
@@ -5405,6 +7155,13 @@
             "name": "Columbus",
             "region": "Georgia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Columbus"
           }
         ]
       }
@@ -5429,6 +7186,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Columbus"
+          }
+        ]
       }
     },
     {
@@ -5448,6 +7212,13 @@
             "name": "Tallahassee",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tallahassee"
           }
         ]
       }
@@ -5472,6 +7243,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tallahassee"
+          }
+        ]
       }
     },
     {
@@ -5491,6 +7269,13 @@
             "name": "Overland Park",
             "region": "Kansas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Overland Park"
           }
         ]
       }
@@ -5515,6 +7300,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Overland Park"
+          }
+        ]
       }
     },
     {
@@ -5534,6 +7326,13 @@
             "name": "Tempe",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tempe"
           }
         ]
       }
@@ -5558,6 +7357,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tempe"
+          }
+        ]
       }
     },
     {
@@ -5577,6 +7383,13 @@
             "name": "McKinney",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of McKinney"
           }
         ]
       }
@@ -5601,6 +7414,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of McKinney"
+          }
+        ]
       }
     },
     {
@@ -5620,6 +7440,13 @@
             "name": "Mobile",
             "region": "Alabama",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Mobile"
           }
         ]
       }
@@ -5644,6 +7471,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Mobile"
+          }
+        ]
       }
     },
     {
@@ -5663,6 +7497,13 @@
             "name": "Cape Coral",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cape Coral"
           }
         ]
       }
@@ -5687,6 +7528,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cape Coral"
+          }
+        ]
       }
     },
     {
@@ -5706,6 +7554,13 @@
             "name": "Shreveport",
             "region": "Louisiana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Shreveport"
           }
         ]
       }
@@ -5730,6 +7585,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Shreveport"
+          }
+        ]
       }
     },
     {
@@ -5749,6 +7611,13 @@
             "name": "Frisco",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Frisco"
           }
         ]
       }
@@ -5773,6 +7642,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Frisco"
+          }
+        ]
       }
     },
     {
@@ -5792,6 +7668,13 @@
             "name": "Knoxville",
             "region": "Tennessee",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Knoxville"
           }
         ]
       }
@@ -5816,6 +7699,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Knoxville"
+          }
+        ]
       }
     },
     {
@@ -5835,6 +7725,13 @@
             "name": "Worcester",
             "region": "Massachusetts",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Worcester"
           }
         ]
       }
@@ -5859,6 +7756,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Worcester"
+          }
+        ]
       }
     },
     {
@@ -5878,6 +7782,13 @@
             "name": "Brownsville",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Brownsville"
           }
         ]
       }
@@ -5902,6 +7813,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Brownsville"
+          }
+        ]
       }
     },
     {
@@ -5921,6 +7839,13 @@
             "name": "Vancouver",
             "region": "Washington",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Vancouver"
           }
         ]
       }
@@ -5945,6 +7870,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Vancouver"
+          }
+        ]
       }
     },
     {
@@ -5964,6 +7896,13 @@
             "name": "Fort Lauderdale",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fort Lauderdale"
           }
         ]
       }
@@ -5988,6 +7927,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fort Lauderdale"
+          }
+        ]
       }
     },
     {
@@ -6007,6 +7953,13 @@
             "name": "Sioux Falls",
             "region": "South Dakota",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sioux Falls"
           }
         ]
       }
@@ -6031,6 +7984,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sioux Falls"
+          }
+        ]
       }
     },
     {
@@ -6050,6 +8010,13 @@
             "name": "Ontario",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Ontario"
           }
         ]
       }
@@ -6074,6 +8041,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Ontario"
+          }
+        ]
       }
     },
     {
@@ -6093,6 +8067,13 @@
             "name": "Chattanooga",
             "region": "Tennessee",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chattanooga"
           }
         ]
       }
@@ -6117,6 +8098,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Chattanooga"
+          }
+        ]
       }
     },
     {
@@ -6136,6 +8124,13 @@
             "name": "Providence",
             "region": "Rhode Island",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Providence"
           }
         ]
       }
@@ -6160,6 +8155,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Providence"
+          }
+        ]
       }
     },
     {
@@ -6179,6 +8181,13 @@
             "name": "Newport News",
             "region": "Virginia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Newport News"
           }
         ]
       }
@@ -6203,6 +8212,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Newport News"
+          }
+        ]
       }
     },
     {
@@ -6222,6 +8238,13 @@
             "name": "Rancho Cucamonga",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rancho Cucamonga"
           }
         ]
       }
@@ -6246,6 +8269,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rancho Cucamonga"
+          }
+        ]
       }
     },
     {
@@ -6265,6 +8295,13 @@
             "name": "Santa Rosa",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Rosa"
           }
         ]
       }
@@ -6289,6 +8326,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Rosa"
+          }
+        ]
       }
     },
     {
@@ -6308,6 +8352,13 @@
             "name": "Oceanside",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Oceanside"
           }
         ]
       }
@@ -6332,6 +8383,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Oceanside"
+          }
+        ]
       }
     },
     {
@@ -6351,6 +8409,13 @@
             "name": "Salem",
             "region": "Oregon",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Salem"
           }
         ]
       }
@@ -6375,6 +8440,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Salem"
+          }
+        ]
       }
     },
     {
@@ -6394,6 +8466,13 @@
             "name": "Elk Grove",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Elk Grove"
           }
         ]
       }
@@ -6418,6 +8497,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Elk Grove"
+          }
+        ]
       }
     },
     {
@@ -6437,6 +8523,13 @@
             "name": "Garden Grove",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Garden Grove"
           }
         ]
       }
@@ -6461,6 +8554,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Garden Grove"
+          }
+        ]
       }
     },
     {
@@ -6480,6 +8580,13 @@
             "name": "Pembroke Pines",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pembroke Pines"
           }
         ]
       }
@@ -6504,6 +8611,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pembroke Pines"
+          }
+        ]
       }
     },
     {
@@ -6523,6 +8637,13 @@
             "name": "Peoria",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Peoria"
           }
         ]
       }
@@ -6547,6 +8668,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Peoria"
+          }
+        ]
       }
     },
     {
@@ -6566,6 +8694,13 @@
             "name": "Eugene",
             "region": "Oregon",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Eugene"
           }
         ]
       }
@@ -6590,6 +8725,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Eugene"
+          }
+        ]
       }
     },
     {
@@ -6609,6 +8751,13 @@
             "name": "Corona",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Corona"
           }
         ]
       }
@@ -6633,6 +8782,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Corona"
+          }
+        ]
       }
     },
     {
@@ -6652,6 +8808,13 @@
             "name": "Cary",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cary"
           }
         ]
       }
@@ -6676,6 +8839,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cary"
+          }
+        ]
       }
     },
     {
@@ -6695,6 +8865,13 @@
             "name": "Springfield",
             "region": "Missouri",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Springfield"
           }
         ]
       }
@@ -6719,6 +8896,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Springfield"
+          }
+        ]
       }
     },
     {
@@ -6738,6 +8922,13 @@
             "name": "Fort Collins",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fort Collins"
           }
         ]
       }
@@ -6762,6 +8953,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fort Collins"
+          }
+        ]
       }
     },
     {
@@ -6781,6 +8979,13 @@
             "name": "Jackson",
             "region": "Mississippi",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Jackson"
           }
         ]
       }
@@ -6805,6 +9010,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Jackson"
+          }
+        ]
       }
     },
     {
@@ -6824,6 +9036,13 @@
             "name": "Alexandria",
             "region": "Virginia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Alexandria"
           }
         ]
       }
@@ -6848,6 +9067,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Alexandria"
+          }
+        ]
       }
     },
     {
@@ -6867,6 +9093,13 @@
             "name": "Hayward",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hayward"
           }
         ]
       }
@@ -6891,6 +9124,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hayward"
+          }
+        ]
       }
     },
     {
@@ -6910,6 +9150,13 @@
             "name": "Lancaster",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lancaster"
           }
         ]
       }
@@ -6934,6 +9181,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lancaster"
+          }
+        ]
       }
     },
     {
@@ -6953,6 +9207,13 @@
             "name": "Lakewood",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lakewood"
           }
         ]
       }
@@ -6977,6 +9238,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lakewood"
+          }
+        ]
       }
     },
     {
@@ -6996,6 +9264,13 @@
             "name": "Clarksville",
             "region": "Tennessee",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Clarksville"
           }
         ]
       }
@@ -7020,6 +9295,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Clarksville"
+          }
+        ]
       }
     },
     {
@@ -7039,6 +9321,13 @@
             "name": "Palmdale",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Palmdale"
           }
         ]
       }
@@ -7063,6 +9352,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Palmdale"
+          }
+        ]
       }
     },
     {
@@ -7082,6 +9378,13 @@
             "name": "Salinas",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Salinas"
           }
         ]
       }
@@ -7106,6 +9409,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Salinas"
+          }
+        ]
       }
     },
     {
@@ -7125,6 +9435,13 @@
             "name": "Springfield",
             "region": "Massachusetts",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Springfield"
           }
         ]
       }
@@ -7149,6 +9466,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Springfield"
+          }
+        ]
       }
     },
     {
@@ -7168,6 +9492,13 @@
             "name": "Hollywood",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hollywood"
           }
         ]
       }
@@ -7192,6 +9523,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hollywood"
+          }
+        ]
       }
     },
     {
@@ -7211,6 +9549,13 @@
             "name": "Pasadena",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pasadena"
           }
         ]
       }
@@ -7235,6 +9580,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pasadena"
+          }
+        ]
       }
     },
     {
@@ -7254,6 +9606,13 @@
             "name": "Sunnyvale",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sunnyvale"
           }
         ]
       }
@@ -7278,6 +9637,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sunnyvale"
+          }
+        ]
       }
     },
     {
@@ -7297,6 +9663,13 @@
             "name": "Macon",
             "region": "Georgia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Macon"
           }
         ]
       }
@@ -7321,6 +9694,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Macon"
+          }
+        ]
       }
     },
     {
@@ -7340,6 +9720,13 @@
             "name": "Kansas City",
             "region": "Kansas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Kansas City"
           }
         ]
       }
@@ -7364,6 +9751,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Kansas City"
+          }
+        ]
       }
     },
     {
@@ -7383,6 +9777,13 @@
             "name": "Pomona",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pomona"
           }
         ]
       }
@@ -7407,6 +9808,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pomona"
+          }
+        ]
       }
     },
     {
@@ -7426,6 +9834,13 @@
             "name": "Escondido",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Escondido"
           }
         ]
       }
@@ -7450,6 +9865,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Escondido"
+          }
+        ]
       }
     },
     {
@@ -7469,6 +9891,13 @@
             "name": "Killeen",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Killeen"
           }
         ]
       }
@@ -7493,6 +9922,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Killeen"
+          }
+        ]
       }
     },
     {
@@ -7512,6 +9948,13 @@
             "name": "Naperville",
             "region": "Illinois",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Naperville"
           }
         ]
       }
@@ -7536,6 +9979,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Naperville"
+          }
+        ]
       }
     },
     {
@@ -7555,6 +10005,13 @@
             "name": "Joliet",
             "region": "Illinois",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Joliet"
           }
         ]
       }
@@ -7579,6 +10036,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Joliet"
+          }
+        ]
       }
     },
     {
@@ -7598,6 +10062,13 @@
             "name": "Bellevue",
             "region": "Washington",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Bellevue"
           }
         ]
       }
@@ -7622,6 +10093,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Bellevue"
+          }
+        ]
       }
     },
     {
@@ -7641,6 +10119,13 @@
             "name": "Rockford",
             "region": "Illinois",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rockford"
           }
         ]
       }
@@ -7665,6 +10150,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rockford"
+          }
+        ]
       }
     },
     {
@@ -7684,6 +10176,13 @@
             "name": "Savannah",
             "region": "Georgia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Savannah"
           }
         ]
       }
@@ -7708,6 +10207,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Savannah"
+          }
+        ]
       }
     },
     {
@@ -7727,6 +10233,13 @@
             "name": "Paterson",
             "region": "New Jersey",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Paterson"
           }
         ]
       }
@@ -7751,6 +10264,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Paterson"
+          }
+        ]
       }
     },
     {
@@ -7770,6 +10290,13 @@
             "name": "Torrance",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Torrance"
           }
         ]
       }
@@ -7794,6 +10321,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Torrance"
+          }
+        ]
       }
     },
     {
@@ -7813,6 +10347,13 @@
             "name": "Bridgeport",
             "region": "Connecticut",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Bridgeport"
           }
         ]
       }
@@ -7837,6 +10378,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Bridgeport"
+          }
+        ]
       }
     },
     {
@@ -7856,6 +10404,13 @@
             "name": "McAllen",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of McAllen"
           }
         ]
       }
@@ -7880,6 +10435,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of McAllen"
+          }
+        ]
       }
     },
     {
@@ -7899,6 +10461,13 @@
             "name": "Mesquite",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Mesquite"
           }
         ]
       }
@@ -7923,6 +10492,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Mesquite"
+          }
+        ]
       }
     },
     {
@@ -7942,6 +10518,13 @@
             "name": "Syracuse",
             "region": "New York",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Syracuse"
           }
         ]
       }
@@ -7966,6 +10549,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Syracuse"
+          }
+        ]
       }
     },
     {
@@ -7985,6 +10575,13 @@
             "name": "Midland",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Midland"
           }
         ]
       }
@@ -8009,6 +10606,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Midland"
+          }
+        ]
       }
     },
     {
@@ -8028,6 +10632,13 @@
             "name": "Pasadena",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pasadena"
           }
         ]
       }
@@ -8052,6 +10663,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pasadena"
+          }
+        ]
       }
     },
     {
@@ -8071,6 +10689,13 @@
             "name": "Murfreesboro",
             "region": "Tennessee",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Murfreesboro"
           }
         ]
       }
@@ -8095,6 +10720,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Murfreesboro"
+          }
+        ]
       }
     },
     {
@@ -8114,6 +10746,13 @@
             "name": "Miramar",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Miramar"
           }
         ]
       }
@@ -8138,6 +10777,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Miramar"
+          }
+        ]
       }
     },
     {
@@ -8157,6 +10803,13 @@
             "name": "Dayton",
             "region": "Ohio",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Dayton"
           }
         ]
       }
@@ -8181,6 +10834,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Dayton"
+          }
+        ]
       }
     },
     {
@@ -8200,6 +10860,13 @@
             "name": "Fullerton",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fullerton"
           }
         ]
       }
@@ -8224,6 +10891,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fullerton"
+          }
+        ]
       }
     },
     {
@@ -8243,6 +10917,13 @@
             "name": "Olathe",
             "region": "Kansas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Olathe"
           }
         ]
       }
@@ -8267,6 +10948,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Olathe"
+          }
+        ]
       }
     },
     {
@@ -8286,6 +10974,13 @@
             "name": "Orange",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Orange"
           }
         ]
       }
@@ -8310,6 +11005,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Orange"
+          }
+        ]
       }
     },
     {
@@ -8329,6 +11031,13 @@
             "name": "Thornton",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Thornton"
           }
         ]
       }
@@ -8353,6 +11062,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Thornton"
+          }
+        ]
       }
     },
     {
@@ -8372,6 +11088,13 @@
             "name": "Roseville",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Roseville"
           }
         ]
       }
@@ -8396,6 +11119,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Roseville"
+          }
+        ]
       }
     },
     {
@@ -8415,6 +11145,13 @@
             "name": "Denton",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Denton"
           }
         ]
       }
@@ -8439,6 +11176,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Denton"
+          }
+        ]
       }
     },
     {
@@ -8458,6 +11202,13 @@
             "name": "Waco",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Waco"
           }
         ]
       }
@@ -8482,6 +11233,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Waco"
+          }
+        ]
       }
     },
     {
@@ -8501,6 +11259,13 @@
             "name": "Surprise",
             "region": "Arizona",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Surprise"
           }
         ]
       }
@@ -8525,6 +11290,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Surprise"
+          }
+        ]
       }
     },
     {
@@ -8544,6 +11316,13 @@
             "name": "Carrollton",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Carrollton"
           }
         ]
       }
@@ -8568,6 +11347,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Carrollton"
+          }
+        ]
       }
     },
     {
@@ -8587,6 +11373,13 @@
             "name": "West Valley City",
             "region": "Utah",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of West Valley City"
           }
         ]
       }
@@ -8611,6 +11404,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of West Valley City"
+          }
+        ]
       }
     },
     {
@@ -8630,6 +11430,13 @@
             "name": "Charleston",
             "region": "South Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Charleston"
           }
         ]
       }
@@ -8654,6 +11461,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Charleston"
+          }
+        ]
       }
     },
     {
@@ -8673,6 +11487,13 @@
             "name": "Warren",
             "region": "Michigan",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Warren"
           }
         ]
       }
@@ -8697,6 +11518,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Warren"
+          }
+        ]
       }
     },
     {
@@ -8716,6 +11544,13 @@
             "name": "Hampton",
             "region": "Virginia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hampton"
           }
         ]
       }
@@ -8740,6 +11575,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hampton"
+          }
+        ]
       }
     },
     {
@@ -8759,6 +11601,13 @@
             "name": "Gainesville",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Gainesville"
           }
         ]
       }
@@ -8783,6 +11632,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Gainesville"
+          }
+        ]
       }
     },
     {
@@ -8802,6 +11658,13 @@
             "name": "Visalia",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Visalia"
           }
         ]
       }
@@ -8826,6 +11689,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Visalia"
+          }
+        ]
       }
     },
     {
@@ -8845,6 +11715,13 @@
             "name": "Coral Springs",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Coral Springs"
           }
         ]
       }
@@ -8869,6 +11746,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Coral Springs"
+          }
+        ]
       }
     },
     {
@@ -8888,6 +11772,13 @@
             "name": "Columbia",
             "region": "South Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Columbia"
           }
         ]
       }
@@ -8912,6 +11803,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Columbia"
+          }
+        ]
       }
     },
     {
@@ -8931,6 +11829,13 @@
             "name": "Cedar Rapids",
             "region": "Iowa",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cedar Rapids"
           }
         ]
       }
@@ -8955,6 +11860,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cedar Rapids"
+          }
+        ]
       }
     },
     {
@@ -8974,6 +11886,13 @@
             "name": "Sterling Heights",
             "region": "Michigan",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sterling Heights"
           }
         ]
       }
@@ -8998,6 +11917,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sterling Heights"
+          }
+        ]
       }
     },
     {
@@ -9017,6 +11943,13 @@
             "name": "New Haven",
             "region": "Connecticut",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of New Haven"
           }
         ]
       }
@@ -9041,6 +11974,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of New Haven"
+          }
+        ]
       }
     },
     {
@@ -9060,6 +12000,13 @@
             "name": "Stamford",
             "region": "Connecticut",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Stamford"
           }
         ]
       }
@@ -9084,6 +12031,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Stamford"
+          }
+        ]
       }
     },
     {
@@ -9103,6 +12057,13 @@
             "name": "Concord",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Concord"
           }
         ]
       }
@@ -9127,6 +12088,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Concord"
+          }
+        ]
       }
     },
     {
@@ -9146,6 +12114,13 @@
             "name": "Kent",
             "region": "Washington",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Kent"
           }
         ]
       }
@@ -9170,6 +12145,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Kent"
+          }
+        ]
       }
     },
     {
@@ -9189,6 +12171,13 @@
             "name": "Santa Clara",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Clara"
           }
         ]
       }
@@ -9213,6 +12202,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Clara"
+          }
+        ]
       }
     },
     {
@@ -9232,6 +12228,13 @@
             "name": "Elizabeth",
             "region": "New Jersey",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Elizabeth"
           }
         ]
       }
@@ -9256,6 +12259,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Elizabeth"
+          }
+        ]
       }
     },
     {
@@ -9275,6 +12285,13 @@
             "name": "Round Rock",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Round Rock"
           }
         ]
       }
@@ -9299,6 +12316,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Round Rock"
+          }
+        ]
       }
     },
     {
@@ -9318,6 +12342,13 @@
             "name": "Thousand Oaks",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Thousand Oaks"
           }
         ]
       }
@@ -9342,6 +12373,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Thousand Oaks"
+          }
+        ]
       }
     },
     {
@@ -9361,6 +12399,13 @@
             "name": "Lafayette",
             "region": "Louisiana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lafayette"
           }
         ]
       }
@@ -9385,6 +12430,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lafayette"
+          }
+        ]
       }
     },
     {
@@ -9404,6 +12456,13 @@
             "name": "Athens",
             "region": "Georgia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Athens"
           }
         ]
       }
@@ -9428,6 +12487,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Athens"
+          }
+        ]
       }
     },
     {
@@ -9447,6 +12513,13 @@
             "name": "Topeka",
             "region": "Kansas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Topeka"
           }
         ]
       }
@@ -9471,6 +12544,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Topeka"
+          }
+        ]
       }
     },
     {
@@ -9490,6 +12570,13 @@
             "name": "Simi Valley",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Simi Valley"
           }
         ]
       }
@@ -9514,6 +12601,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Simi Valley"
+          }
+        ]
       }
     },
     {
@@ -9533,6 +12627,13 @@
             "name": "Fargo",
             "region": "North Dakota",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fargo"
           }
         ]
       }
@@ -9557,6 +12658,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fargo"
+          }
+        ]
       }
     },
     {
@@ -9576,6 +12684,13 @@
             "name": "Norman",
             "region": "Oklahoma",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Norman"
           }
         ]
       }
@@ -9600,6 +12715,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Norman"
+          }
+        ]
       }
     },
     {
@@ -9619,6 +12741,13 @@
             "name": "Columbia",
             "region": "Missouri",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Columbia"
           }
         ]
       }
@@ -9643,6 +12772,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Columbia"
+          }
+        ]
       }
     },
     {
@@ -9662,6 +12798,13 @@
             "name": "Abilene",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Abilene"
           }
         ]
       }
@@ -9686,6 +12829,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Abilene"
+          }
+        ]
       }
     },
     {
@@ -9705,6 +12855,13 @@
             "name": "Wilmington",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Wilmington"
           }
         ]
       }
@@ -9729,6 +12886,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Wilmington"
+          }
+        ]
       }
     },
     {
@@ -9748,6 +12912,13 @@
             "name": "Hartford",
             "region": "Connecticut",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hartford"
           }
         ]
       }
@@ -9772,6 +12943,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hartford"
+          }
+        ]
       }
     },
     {
@@ -9791,6 +12969,13 @@
             "name": "Victorville",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Victorville"
           }
         ]
       }
@@ -9815,6 +13000,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Victorville"
+          }
+        ]
       }
     },
     {
@@ -9834,6 +13026,13 @@
             "name": "Pearland",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pearland"
           }
         ]
       }
@@ -9858,6 +13057,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pearland"
+          }
+        ]
       }
     },
     {
@@ -9877,6 +13083,13 @@
             "name": "Vallejo",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Vallejo"
           }
         ]
       }
@@ -9901,6 +13114,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Vallejo"
+          }
+        ]
       }
     },
     {
@@ -9920,6 +13140,13 @@
             "name": "Ann Arbor",
             "region": "Michigan",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Ann Arbor"
           }
         ]
       }
@@ -9944,6 +13171,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Ann Arbor"
+          }
+        ]
       }
     },
     {
@@ -9963,6 +13197,13 @@
             "name": "Berkeley",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Berkeley"
           }
         ]
       }
@@ -9987,6 +13228,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Berkeley"
+          }
+        ]
       }
     },
     {
@@ -10006,6 +13254,13 @@
             "name": "Allentown",
             "region": "Pennsylvania",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Allentown"
           }
         ]
       }
@@ -10030,6 +13285,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Allentown"
+          }
+        ]
       }
     },
     {
@@ -10049,6 +13311,13 @@
             "name": "Richardson",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Richardson"
           }
         ]
       }
@@ -10073,6 +13342,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Richardson"
+          }
+        ]
       }
     },
     {
@@ -10092,6 +13368,13 @@
             "name": "Odessa",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Odessa"
           }
         ]
       }
@@ -10116,6 +13399,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Odessa"
+          }
+        ]
       }
     },
     {
@@ -10135,6 +13425,13 @@
             "name": "Arvada",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Arvada"
           }
         ]
       }
@@ -10159,6 +13456,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Arvada"
+          }
+        ]
       }
     },
     {
@@ -10178,6 +13482,13 @@
             "name": "Cambridge",
             "region": "Massachusetts",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cambridge"
           }
         ]
       }
@@ -10202,6 +13513,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Cambridge"
+          }
+        ]
       }
     },
     {
@@ -10221,6 +13539,13 @@
             "name": "Sugar Land",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sugar Land"
           }
         ]
       }
@@ -10245,6 +13570,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sugar Land"
+          }
+        ]
       }
     },
     {
@@ -10264,6 +13596,13 @@
             "name": "Beaumont",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Beaumont"
           }
         ]
       }
@@ -10288,6 +13627,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Beaumont"
+          }
+        ]
       }
     },
     {
@@ -10307,6 +13653,13 @@
             "name": "Lansing",
             "region": "Michigan",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lansing"
           }
         ]
       }
@@ -10331,6 +13684,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lansing"
+          }
+        ]
       }
     },
     {
@@ -10350,6 +13710,13 @@
             "name": "Evansville",
             "region": "Indiana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Evansville"
           }
         ]
       }
@@ -10374,6 +13741,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Evansville"
+          }
+        ]
       }
     },
     {
@@ -10393,6 +13767,13 @@
             "name": "Rochester",
             "region": "Minnesota",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rochester"
           }
         ]
       }
@@ -10417,6 +13798,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rochester"
+          }
+        ]
       }
     },
     {
@@ -10436,6 +13824,13 @@
             "name": "Independence",
             "region": "Missouri",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Independence"
           }
         ]
       }
@@ -10460,6 +13855,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Independence"
+          }
+        ]
       }
     },
     {
@@ -10479,6 +13881,13 @@
             "name": "Fairfield",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fairfield"
           }
         ]
       }
@@ -10503,6 +13912,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Fairfield"
+          }
+        ]
       }
     },
     {
@@ -10522,6 +13938,13 @@
             "name": "Provo",
             "region": "Utah",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Provo"
           }
         ]
       }
@@ -10546,6 +13969,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Provo"
+          }
+        ]
       }
     },
     {
@@ -10565,6 +13995,13 @@
             "name": "Clearwater",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Clearwater"
           }
         ]
       }
@@ -10589,6 +14026,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Clearwater"
+          }
+        ]
       }
     },
     {
@@ -10608,6 +14052,13 @@
             "name": "College Station",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of College Station"
           }
         ]
       }
@@ -10632,6 +14083,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of College Station"
+          }
+        ]
       }
     },
     {
@@ -10651,6 +14109,13 @@
             "name": "West Jordan",
             "region": "Utah",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of West Jordan"
           }
         ]
       }
@@ -10675,6 +14140,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of West Jordan"
+          }
+        ]
       }
     },
     {
@@ -10694,6 +14166,13 @@
             "name": "Carlsbad",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Carlsbad"
           }
         ]
       }
@@ -10718,6 +14197,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Carlsbad"
+          }
+        ]
       }
     },
     {
@@ -10737,6 +14223,13 @@
             "name": "El Monte",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of El Monte"
           }
         ]
       }
@@ -10761,6 +14254,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of El Monte"
+          }
+        ]
       }
     },
     {
@@ -10780,6 +14280,13 @@
             "name": "Murrieta",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Murrieta"
           }
         ]
       }
@@ -10804,6 +14311,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Murrieta"
+          }
+        ]
       }
     },
     {
@@ -10823,6 +14337,13 @@
             "name": "Temecula",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Temecula"
           }
         ]
       }
@@ -10847,6 +14368,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Temecula"
+          }
+        ]
       }
     },
     {
@@ -10866,6 +14394,13 @@
             "name": "Springfield",
             "region": "Illinois",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Springfield"
           }
         ]
       }
@@ -10890,6 +14425,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Springfield"
+          }
+        ]
       }
     },
     {
@@ -10909,6 +14451,13 @@
             "name": "Palm Bay",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Palm Bay"
           }
         ]
       }
@@ -10933,6 +14482,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Palm Bay"
+          }
+        ]
       }
     },
     {
@@ -10952,6 +14508,13 @@
             "name": "Costa Mesa",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Costa Mesa"
           }
         ]
       }
@@ -10976,6 +14539,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Costa Mesa"
+          }
+        ]
       }
     },
     {
@@ -10995,6 +14565,13 @@
             "name": "Westminster",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Westminster"
           }
         ]
       }
@@ -11019,6 +14596,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Westminster"
+          }
+        ]
       }
     },
     {
@@ -11038,6 +14622,13 @@
             "name": "North Charleston",
             "region": "South Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of North Charleston"
           }
         ]
       }
@@ -11062,6 +14653,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of North Charleston"
+          }
+        ]
       }
     },
     {
@@ -11081,6 +14679,13 @@
             "name": "Miami Gardens",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Miami Gardens"
           }
         ]
       }
@@ -11105,6 +14710,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Miami Gardens"
+          }
+        ]
       }
     },
     {
@@ -11124,6 +14736,13 @@
             "name": "Manchester",
             "region": "New Hampshire",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Manchester"
           }
         ]
       }
@@ -11148,6 +14767,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Manchester"
+          }
+        ]
       }
     },
     {
@@ -11167,6 +14793,13 @@
             "name": "High Point",
             "region": "North Carolina",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of High Point"
           }
         ]
       }
@@ -11191,6 +14824,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of High Point"
+          }
+        ]
       }
     },
     {
@@ -11210,6 +14850,13 @@
             "name": "Downey",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Downey"
           }
         ]
       }
@@ -11234,6 +14881,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Downey"
+          }
+        ]
       }
     },
     {
@@ -11253,6 +14907,13 @@
             "name": "Clovis",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Clovis"
           }
         ]
       }
@@ -11277,6 +14938,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Clovis"
+          }
+        ]
       }
     },
     {
@@ -11296,6 +14964,13 @@
             "name": "Pompano Beach",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pompano Beach"
           }
         ]
       }
@@ -11320,6 +14995,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pompano Beach"
+          }
+        ]
       }
     },
     {
@@ -11339,6 +15021,13 @@
             "name": "Pueblo",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pueblo"
           }
         ]
       }
@@ -11363,6 +15052,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Pueblo"
+          }
+        ]
       }
     },
     {
@@ -11382,6 +15078,13 @@
             "name": "Elgin",
             "region": "Illinois",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Elgin"
           }
         ]
       }
@@ -11406,6 +15109,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Elgin"
+          }
+        ]
       }
     },
     {
@@ -11425,6 +15135,13 @@
             "name": "Lowell",
             "region": "Massachusetts",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lowell"
           }
         ]
       }
@@ -11449,6 +15166,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lowell"
+          }
+        ]
       }
     },
     {
@@ -11468,6 +15192,13 @@
             "name": "Antioch",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Antioch"
           }
         ]
       }
@@ -11492,6 +15223,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Antioch"
+          }
+        ]
       }
     },
     {
@@ -11511,6 +15249,13 @@
             "name": "West Palm Beach",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of West Palm Beach"
           }
         ]
       }
@@ -11535,6 +15280,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of West Palm Beach"
+          }
+        ]
       }
     },
     {
@@ -11554,6 +15306,13 @@
             "name": "Peoria",
             "region": "Illinois",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Peoria"
           }
         ]
       }
@@ -11578,6 +15337,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Peoria"
+          }
+        ]
       }
     },
     {
@@ -11597,6 +15363,13 @@
             "name": "Everett",
             "region": "Washington",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Everett"
           }
         ]
       }
@@ -11621,6 +15394,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Everett"
+          }
+        ]
       }
     },
     {
@@ -11640,6 +15420,13 @@
             "name": "Ventura",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Ventura"
           }
         ]
       }
@@ -11664,6 +15451,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Ventura"
+          }
+        ]
       }
     },
     {
@@ -11683,6 +15477,13 @@
             "name": "Centennial",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Centennial"
           }
         ]
       }
@@ -11707,6 +15508,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Centennial"
+          }
+        ]
       }
     },
     {
@@ -11726,6 +15534,13 @@
             "name": "Lakeland",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lakeland"
           }
         ]
       }
@@ -11750,6 +15565,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lakeland"
+          }
+        ]
       }
     },
     {
@@ -11769,6 +15591,13 @@
             "name": "Gresham",
             "region": "Oregon",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Gresham"
           }
         ]
       }
@@ -11793,6 +15622,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Gresham"
+          }
+        ]
       }
     },
     {
@@ -11812,6 +15648,13 @@
             "name": "Richmond",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Richmond"
           }
         ]
       }
@@ -11836,6 +15679,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Richmond"
+          }
+        ]
       }
     },
     {
@@ -11855,6 +15705,13 @@
             "name": "Billings",
             "region": "Montana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Billings"
           }
         ]
       }
@@ -11879,6 +15736,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Billings"
+          }
+        ]
       }
     },
     {
@@ -11898,6 +15762,13 @@
             "name": "Inglewood",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Inglewood"
           }
         ]
       }
@@ -11922,6 +15793,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Inglewood"
+          }
+        ]
       }
     },
     {
@@ -11941,6 +15819,13 @@
             "name": "Broken Arrow",
             "region": "Oklahoma",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Broken Arrow"
           }
         ]
       }
@@ -11965,6 +15850,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Broken Arrow"
+          }
+        ]
       }
     },
     {
@@ -11984,6 +15876,13 @@
             "name": "Sandy Springs",
             "region": "Georgia",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sandy Springs"
           }
         ]
       }
@@ -12008,6 +15907,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sandy Springs"
+          }
+        ]
       }
     },
     {
@@ -12027,6 +15933,13 @@
             "name": "Jurupa Valley",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Jurupa Valley"
           }
         ]
       }
@@ -12051,6 +15964,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Jurupa Valley"
+          }
+        ]
       }
     },
     {
@@ -12070,6 +15990,13 @@
             "name": "Hillsboro",
             "region": "Oregon",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hillsboro"
           }
         ]
       }
@@ -12094,6 +16021,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Hillsboro"
+          }
+        ]
       }
     },
     {
@@ -12113,6 +16047,13 @@
             "name": "Waterbury",
             "region": "Connecticut",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Waterbury"
           }
         ]
       }
@@ -12137,6 +16078,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Waterbury"
+          }
+        ]
       }
     },
     {
@@ -12156,6 +16104,13 @@
             "name": "Santa Maria",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Maria"
           }
         ]
       }
@@ -12180,6 +16135,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Santa Maria"
+          }
+        ]
       }
     },
     {
@@ -12199,6 +16161,13 @@
             "name": "Boulder",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Boulder"
           }
         ]
       }
@@ -12223,6 +16192,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Boulder"
+          }
+        ]
       }
     },
     {
@@ -12242,6 +16218,13 @@
             "name": "Greeley",
             "region": "Colorado",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Greeley"
           }
         ]
       }
@@ -12266,6 +16249,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Greeley"
+          }
+        ]
       }
     },
     {
@@ -12285,6 +16275,13 @@
             "name": "Daly City",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Daly City"
           }
         ]
       }
@@ -12309,6 +16306,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Daly City"
+          }
+        ]
       }
     },
     {
@@ -12328,6 +16332,13 @@
             "name": "Meridian",
             "region": "Idaho",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Meridian"
           }
         ]
       }
@@ -12352,6 +16363,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Meridian"
+          }
+        ]
       }
     },
     {
@@ -12371,6 +16389,13 @@
             "name": "Lewisville",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lewisville"
           }
         ]
       }
@@ -12395,6 +16420,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lewisville"
+          }
+        ]
       }
     },
     {
@@ -12414,6 +16446,13 @@
             "name": "Davie",
             "region": "Florida",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Davie"
           }
         ]
       }
@@ -12438,6 +16477,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Davie"
+          }
+        ]
       }
     },
     {
@@ -12457,6 +16503,13 @@
             "name": "West Covina",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of West Covina"
           }
         ]
       }
@@ -12481,6 +16534,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of West Covina"
+          }
+        ]
       }
     },
     {
@@ -12500,6 +16560,13 @@
             "name": "League City",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of League City"
           }
         ]
       }
@@ -12524,6 +16591,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of League City"
+          }
+        ]
       }
     },
     {
@@ -12543,6 +16617,13 @@
             "name": "Tyler",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tyler"
           }
         ]
       }
@@ -12567,6 +16648,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tyler"
+          }
+        ]
       }
     },
     {
@@ -12586,6 +16674,13 @@
             "name": "Norwalk",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Norwalk"
           }
         ]
       }
@@ -12610,6 +16705,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Norwalk"
+          }
+        ]
       }
     },
     {
@@ -12629,6 +16731,13 @@
             "name": "San Mateo",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Mateo"
           }
         ]
       }
@@ -12653,6 +16762,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Mateo"
+          }
+        ]
       }
     },
     {
@@ -12672,6 +16788,13 @@
             "name": "Green Bay",
             "region": "Wisconsin",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Green Bay"
           }
         ]
       }
@@ -12696,6 +16819,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Green Bay"
+          }
+        ]
       }
     },
     {
@@ -12715,6 +16845,13 @@
             "name": "Wichita Falls",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Wichita Falls"
           }
         ]
       }
@@ -12739,6 +16876,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Wichita Falls"
+          }
+        ]
       }
     },
     {
@@ -12758,6 +16902,13 @@
             "name": "Sparks",
             "region": "Nevada",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sparks"
           }
         ]
       }
@@ -12782,6 +16933,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Sparks"
+          }
+        ]
       }
     },
     {
@@ -12801,6 +16959,13 @@
             "name": "Lakewood",
             "region": "New Jersey",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lakewood"
           }
         ]
       }
@@ -12825,6 +16990,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Lakewood"
+          }
+        ]
       }
     },
     {
@@ -12844,6 +17016,13 @@
             "name": "Burbank",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Burbank"
           }
         ]
       }
@@ -12868,6 +17047,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Burbank"
+          }
+        ]
       }
     },
     {
@@ -12887,6 +17073,13 @@
             "name": "Rialto",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rialto"
           }
         ]
       }
@@ -12911,6 +17104,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Rialto"
+          }
+        ]
       }
     },
     {
@@ -12930,6 +17130,13 @@
             "name": "Allen",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Allen"
           }
         ]
       }
@@ -12954,6 +17161,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Allen"
+          }
+        ]
       }
     },
     {
@@ -12973,6 +17187,13 @@
             "name": "El Cajon",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of El Cajon"
           }
         ]
       }
@@ -12997,6 +17218,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of El Cajon"
+          }
+        ]
       }
     },
     {
@@ -13016,6 +17244,13 @@
             "name": "Las Cruces",
             "region": "New Mexico",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Las Cruces"
           }
         ]
       }
@@ -13040,6 +17275,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Las Cruces"
+          }
+        ]
       }
     },
     {
@@ -13059,6 +17301,13 @@
             "name": "Renton",
             "region": "Washington",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Renton"
           }
         ]
       }
@@ -13083,6 +17332,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Renton"
+          }
+        ]
       }
     },
     {
@@ -13102,6 +17358,13 @@
             "name": "Davenport",
             "region": "Iowa",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Davenport"
           }
         ]
       }
@@ -13126,6 +17389,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Davenport"
+          }
+        ]
       }
     },
     {
@@ -13145,6 +17415,13 @@
             "name": "South Bend",
             "region": "Indiana",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of South Bend"
           }
         ]
       }
@@ -13169,6 +17446,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of South Bend"
+          }
+        ]
       }
     },
     {
@@ -13188,6 +17472,13 @@
             "name": "Vista",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Vista"
           }
         ]
       }
@@ -13212,6 +17503,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Vista"
+          }
+        ]
       }
     },
     {
@@ -13231,6 +17529,13 @@
             "name": "Tuscaloosa",
             "region": "Alabama",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tuscaloosa"
           }
         ]
       }
@@ -13255,6 +17560,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Tuscaloosa"
+          }
+        ]
       }
     },
     {
@@ -13274,6 +17586,13 @@
             "name": "Clinton",
             "region": "Michigan",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Clinton"
           }
         ]
       }
@@ -13298,6 +17617,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Clinton"
+          }
+        ]
       }
     },
     {
@@ -13317,6 +17643,13 @@
             "name": "Edison",
             "region": "New Jersey",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Edison"
           }
         ]
       }
@@ -13341,6 +17674,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Edison"
+          }
+        ]
       }
     },
     {
@@ -13360,6 +17700,13 @@
             "name": "Woodbridge",
             "region": "New Jersey",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Woodbridge"
           }
         ]
       }
@@ -13384,6 +17731,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Woodbridge"
+          }
+        ]
       }
     },
     {
@@ -13403,6 +17757,13 @@
             "name": "San Angelo",
             "region": "Texas",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Angelo"
           }
         ]
       }
@@ -13427,6 +17788,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of San Angelo"
+          }
+        ]
       }
     },
     {
@@ -13446,6 +17814,13 @@
             "name": "Kenosha",
             "region": "Wisconsin",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Kenosha"
           }
         ]
       }
@@ -13470,6 +17845,13 @@
             "country_a": "USA"
           }
         ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Kenosha"
+          }
+        ]
       }
     },
     {
@@ -13489,6 +17871,13 @@
             "name": "Vacaville",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Vacaville"
           }
         ]
       }
@@ -13511,6 +17900,13 @@
             "name": "Vacaville",
             "region": "California",
             "country_a": "USA"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "City of Vacaville"
           }
         ]
       }


### PR DESCRIPTION
This PR adds a bunch of new expectations that check for undesireable "City of X" records in our `top_us_cities` test suite.

It really helps emphasize the impact of deduplication work and https://github.com/pelias/api/pull/1615 in particular.

It required https://github.com/pelias/fuzzy-tester/pull/208 to fix a bug in `unexpected` test expectations in the fuzzy-tester.